### PR TITLE
Symbolic Docs (pt.I)

### DIFF
--- a/docs/stylesheets/extra.css
+++ b/docs/stylesheets/extra.css
@@ -1,0 +1,17 @@
+:root {
+  --md-admonition-icon--coming-soon: url('data:image/svg+xml;charset=utf-8,<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512"><!--! Font Awesome Free 6.6.0 by @fontawesome - https://fontawesome.com License - https://fontawesome.com/license/free (Icons: CC BY 4.0, Fonts: SIL OFL 1.1, Code: MIT License) Copyright 2024 Fonticons, Inc.--><path d="M464 256a208 208 0 1 1-416 0 208 208 0 1 1 416 0M0 256a256 256 0 1 0 512 0 256 256 0 1 0-512 0m232-136v136c0 8 4 15.5 10.7 20l96 64c11 7.4 25.9 4.4 33.3-6.7s4.4-25.9-6.7-33.3L280 243.2V120c0-13.3-10.7-24-24-24s-24 10.7-24 24"/></svg>')
+}
+.md-typeset .admonition.coming-soon,
+.md-typeset details.coming-soon {
+  border-color: rgb(68, 138, 255);
+}
+.md-typeset .coming-soon > .admonition-title,
+.md-typeset .coming-soon > summary {
+  background-color: rgba(68, 138, 255, 0.1);
+}
+.md-typeset .coming-soon > .admonition-title::before,
+.md-typeset .coming-soon > summary::before {
+  background-color: rgb(68, 138, 255);
+  -webkit-mask-image: var(--md-admonition-icon--coming-soon);
+          mask-image: var(--md-admonition-icon--coming-soon);
+}

--- a/docs/symbolic/coding/basic-types.md
+++ b/docs/symbolic/coding/basic-types.md
@@ -1,1 +1,120 @@
 # Basic Types
+
+Here are some of the types from Symbolic Standard Library which you are most
+likely to encounter while working with the language. All of them implement
+both `SymbolicData` and `SymbolicInput` except for `(e -> a)`, which is only
+`SymbolicData`.
+
+`Bool c`
+
+:   Symbolic datatype corresponding to the usual boolean value. Supports basic
+    boolean operations (`&&`, `||`, `not`, `xor` etc.) and conditional branching
+    &mdash; as long as the resulting type is `SymbolicData`:
+
+    ```haskell
+    import ZkFold.Symbolic.Data.Conditional  (bool)
+    import ZkFold.Symbolic.Data.Eq           ((==))
+    import ZkFold.Symbolic.Data.FieldElement (FieldElement)
+
+    safeInv :: Symbolic c => FieldElement c -> FieldElement c -> FieldElement c
+    safeInv default_ x = bool (finv x) default_ (x == zero)
+    ```
+
+    Located in `ZkFold.Symbolic.Data.Bool`.
+
+`FieldElement c`
+
+:   Corresponds to a single native field element of a context `c`. Supports
+    comparison, all field operations and can be obtained from `Natural`,
+    `Integer` and from the Haskell value of a native field element (the latter
+    is called `BaseField c`).
+
+    Located in `ZkFold.Symbolic.Data.FieldElement`.
+
+`ByteString n c`
+
+:   Fixed-size bytestring. Supports equality, bitwise logical operations and
+    various operations which treat it as a contiguous sequence of elements
+    (bits): concatenation, reversing, truncation, extension etc.
+
+    Most operations require `KnownNat n`, which is to be expected.
+
+    Located in `ZkFold.Symbolic.Data.ByteString`.
+
+`(x, y)`
+
+:   As long as both `x` and `y` are `SymbolicData` (`SymbolicInput`), a pair
+    (and, in general, a tuple) of them is, too.
+
+`e -> a`
+
+:   As long as `a` is `SymbolicData`, `e -> a` is, too. Unfortunately, the same
+    doesn't hold for `SymbolicInput`, so we currently cannot compile functions
+    which take another function as input; however, thanks to `SymbolicData`
+    instance, both currying and branching via `Bool c` work with functions.
+
+`Vector n x`
+
+:   This is our custom "fixed-size" vector type. Usually, we use it in an
+    ordinary Haskell code. However, as long as `x` is `SymbolicData`
+    (`SymbolicInput`) and `n` is `KnownNat`, a `Vector` of them is, too.
+
+    Definition of a `Vector` can be found in `ZkFold.Base.Data.Vector`.
+
+`Maybe c x`
+
+:   Symbolic `Maybe` datatype. As long as `x` is `SymbolicData` in context `c`,
+    `Maybe c x` is, too, and provides familiar `Maybe` interface: construnctors
+    `just`, `nothing`, as well as `maybe` combinator.
+
+!!! coming-soon "Coming soon"
+
+    While sum types cannot be `SymbolicData` as-is, soon we will offer a
+    lightweight wrapper which can turn any algebraic datatype containing
+    Symbolic datatypes into their Symbolic counterpart.
+
+`UInt n r c`
+
+:   Fixed-width unsigned integer. Supports comparison, all ring operations which
+    treat it as a residue modulo `2^n` and can be obtained from `Natural`,
+    `Integer` and from `FieldElement c` as long as `n` is big enough.
+
+    `r` is a register size which can be tweaked in different usecases for
+    maximum performance. Can be set either to `Auto` which greedily chooses
+    biggest registers or to `Fixed m` where `m` is fixed number of bits in a
+    register.
+
+    Most operations require `KnownNat (NumberOfRegisters (BaseField c) n r)`.
+
+    Located in `ZkFold.Symbolic.Data.UInt`.
+
+!!! coming-soon "Coming soon"
+
+    Actually, using `NumberOfRegisters` slows down compilation of Haskell code
+    quite a bit and also hurts readability, so we are going to get rid of this
+    constraint soon and only require `KnownNat n` and `KnownRegisterSize r`.
+
+`FFA p c`
+
+:   Foreign-field arithmetic modulo `p` inside arbitrary context `c`. Currently
+    only ring operations are supported.
+
+    Located in `ZkFold.Symbolic.Data.FFA`.
+
+!!! coming-soon "Coming soon"
+
+    Soon, we will migrate FFA to more efficient implementation, which would also
+    allow for exact equality and fast exponentiation.
+
+`Point (Ed25519 c)`
+
+:   Point of an Edwards 25519 curve as a Symbolic datatype. Supports basic curve
+    operations.
+
+!!! coming-soon "Coming soon"
+
+    Currently we are in an active process of integrating Incrementally
+    Verifiable Computations (IVCs) into zkFold Symbolic. Based on this
+    technique, soon we will be able to provide arbitrarily-sized types for
+    Symbolic, including `List`s, arbitrary-sized `ByteString`s,
+    arbitrary-precision arithmetic and more!

--- a/docs/symbolic/coding/getting-started.md
+++ b/docs/symbolic/coding/getting-started.md
@@ -2,9 +2,131 @@
 
 ## Symbolic Fundamentals
 
-zkFold Symbolic uses the Haskell type system to distinguish arithmetizable computations from non-arithmetizable ones. Every arithmetizable function must be polymorphic in the _context variable_ `c` satisfying the type constraint `Symbolic c`. This allows us to manipulate the function as a mathematical expression and compile it to an arithmetic circuit as well as evaluate it on concrete inputs.
+zkFold Symbolic doesn't rely on any GHC compiler magic or compiler plugins:
+Symbolic code is usual Haskell code, compiled by usual GHC 9.6.0 compiler.
+We only use the Haskell type system in a smart way to distinguish arithmetizable
+computations from non-arithmetizable ones. While this is great, this also means
+that at least basic knowledge of Haskell language is required; we advise to at
+least get comfortable with the syntax first.
 
-A sufficient condition for a function to be arithmetizable is that all its arguments and the return value belong to the class `SymbolicData c`. Our Standard Library provides a collection of basic types with instances of `SymbolicData c`. Basic types are covered on [the next page](basic-types.md) of this documentation. Oftentimes, when building on top of those basic types, developers can derive instances of `SymbolicData c` for their custom types. We will discuss custom type implementation on the [Custom Types page](custom-types.md).
+Now, back to Symbolic. It is distinguished from simple Haskell by presence of
+the _context type variable_ `c` satisfying the type constraint `Symbolic c`
+which is later used in Symbolic data types. For example, here is the Symbolic
+function which, given a native field element and a `ByteString` of length 256,
+computes MiMC hash on the contents of a bytestring and compares it with the
+expected result:
+
+```haskell
+{-# LANGUAGE DataKinds         #-}
+{-# LANGUAGE NoImplicitPrelude #-}
+
+import ZkFold.Symbolic.Algorithms.Hash.MiMC (hash)
+import ZkFold.Symbolic.Class                (Symbolic)
+import ZkFold.Symbolic.Data.Bool            (Bool)
+import ZkFold.Symbolic.Data.ByteString      (ByteString)
+import ZkFold.Symbolic.Data.Eq              ((==))
+import ZkFold.Symbolic.Data.FieldElement    (FieldElement)
+
+checkHash :: Symbolic c => FieldElement c -> ByteString 256 c -> Bool c
+checkHash expected byteString = hash byteString == expected
+```
+
+!!! coming-soon "Coming soon"
+
+    If you too are worried by the amount of the `import` stanzas, you are not
+    alone. Soon we will define the `ZkFold.Symbolic.Prelude` module which would
+    reexport the most useful definitions of Symbolic Standard Library.
+
+The main benefit of making all functions polymorphic in `c` is that it allows us
+to reinterpret them in a plethora of different ways, most notably both as a
+blueprint for an arithmetic circuit used in a zkSNARK and as a pure function to
+be evaluated on concrete inputs.
+
+While there is no restriction on which functions can be written and reused in
+other functions (as zkFold Symbolic code is just Haskell code), for a function
+to be __compilable into a circuit__, certain conditions have to be satisfied:
+
+1. All of its arguments are an instance of `SymbolicInput`;
+2. Its return type is `SymbolicData`.
+
+`checkHash` satisfies these constraints, so we can compile it with, you guessed
+it, `compile` function and print the compiled circuit:
+
+```haskell
+import ZkFold.Symbolic.Compiler (compile)
+import MyExample                (checkHash)
+
+printCheckHashAC :: IO ()
+printCheckHashAC = print (compile checkHash)
+```
+
+Our Standard Library provides a collection of basic types with instances of
+both `SymbolicInput` and `SymbolicData`. Basic types are covered on
+[the next page](basic-types.md) of this documentation. When building on top of
+those basic types, developers can write down their own instances of
+`SymbolicInput` and `SymbolicData` for their custom types. We will discuss
+custom type implementation on the [Custom Types page](custom-types.md).
+
+## Tips and tricks
+
+### Higher-order functions
+
+Being usual Haskell code, zkFold Symbolic admits usual Haskell idioms, including
+polymorphism, monads, higher-order functions and whatnot. For example, we could
+rewrite our `checkHash` function in the following way:
+
+```haskell
+import ZkFold.Symbolic.Algorithms.Hash.MiMC qualified as MiMC
+
+checkWith ::
+    Symbolic c =>
+    FieldElement c -> (ByteString c -> FieldElement c) -> ByteString c -> Bool c
+checkWith expected hash byteString = hash byteString == expected
+
+checkHash :: Symbolic c => FieldElement c -> ByteString c -> Bool c
+checkHash expected = checkWith expected MiMC.hash
+```
+
+And this would still compile just fine &mdash; and to the same circuit as
+before, even &mdash; nevermind the higher-order functions and eta-reduction.
+Once again: anything goes as long as the function which ends up being compiled
+satisfies the constraints outlined above.
+
+### Embedding Haskell values
+
+While there is typically no way to obtain the value of a Symbolic datatype
+inside a Symbolic function (because, in an arbitrary context, there might be no
+such thing as "value" to worry about, at all), going in the other direction is
+dead simple: just call the conversion function! At zkFold, we call this
+conversion function `fromConstant`.
+
+Now, for a final version of a `checkHash`:
+
+```haskell
+import Numeric.Natural                 (Natural)
+
+import ZkFold.Base.Algebra.Basic.Class (FromConstant (..))
+
+checkWith' ::
+    (Symbolic c, FromConstant a (FieldElement c)) =>
+    a -> (ByteString c -> FieldElement c) -> ByteString c -> Bool c
+checkWith' expected hash byteString = hash byteString == fromConstant expected
+
+checkHash' :: Symbolic c => ByteString c -> Bool c
+checkHash' = checkWith' (0xDEADF00D :: Natural) MiMC.hash
+```
+
+Few things to note:
+
+1. As can be expected from its type, `checkHash'` compiles fine, too.
+2. As provided `expected` value is constant, it can (and will) be encoded in the
+   circuit using fewer constraints, bringing further optimizations!
+
+!!! danger
+
+    As always is with sensitive information, care must be taken: do not use this
+    technique to encode private values inside the circuit! Anyone who gets to
+    view the contents of the circuit can extract the information easily.
 
 <!-- ## Framework Overview
 

--- a/docs/symbolic/introduction.md
+++ b/docs/symbolic/introduction.md
@@ -18,9 +18,7 @@ zkFold Symbolic compiler generally produces near-optimal arithmetic circuits fro
 ### Correct-by-construction arithmetic circuits
 Coding arithmetic circuits in a low-level language bears a significant probability of introducing errors that invalidate the security of the underlying business logic. This can be avoided by using zkFold Symbolic's standard type library as well as any custom types and functions defined on top of it. The developers can focus on the business logic of their application while the compiler takes care of the correctness of the arithmetic circuits.
 
-Additionally, zkFold Symbolic provides built-in tests for any user-generated function. In particular, the tests verify that the function and its circuit representation implement the same map from the inputs to the output.
-
-Finally, the zkFold Symbolic compiler is very compact, spanning just a few thousand lines of code, making it easy to audit.
+In addition, the zkFold Symbolic compiler is very compact, spanning just a few thousand lines of code, making it easy to audit.
 
 ### Low barrier to entry
 In zkFold Symbolic, developers implement zero knowledge programs, i.e. statements to prove and verify, as pure, polymorphic Haskell functions. The complementing zero knowledge proof protocols are provided as easy-to-use APIs. Thus, in-depth knowledge of the underlying cryptography is not required.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -72,6 +72,7 @@ extra:
 
 markdown_extensions:
   - admonition
+  - def_list
   - toc:
       permalink: true
       toc_depth: 3

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,3 +1,4 @@
+# yaml-language-server: $schema=https://squidfunk.github.io/mkdocs-material/schema.json
 copyright: Copyright &copy; 2024 <a href="https://zkfold.io" target="_blank" rel="noopener">zkFold SA</a>
 site_name: "zkFold Products User Documentation"
 site_url: https://docs.zkfold.io
@@ -70,6 +71,7 @@ extra:
       lang: en
 
 markdown_extensions:
+  - admonition
   - toc:
       permalink: true
       toc_depth: 3
@@ -82,6 +84,9 @@ markdown_extensions:
   - pymdownx.inlinehilite
   - pymdownx.snippets
   - pymdownx.superfences
+
+extra_css:
+  - stylesheets/extra.css
 
 extra_javascript:
   - javascripts/mathjax.js


### PR DESCRIPTION
This PR adds introductory documentation for zkFold Symbolic DSL, containing general info abt the language, small script compilation example, some basic tricks and techniques, as well as description of all basic Symbolic datatypes.